### PR TITLE
DfmCheck/PascalParser: Unterstützung für Units mit Namespace

### DIFF
--- a/Source/DfmCheck_Utils.pas
+++ b/Source/DfmCheck_Utils.pas
@@ -566,6 +566,7 @@ var
   N, FN: string;
   Parser: TPascalParser;
   Token: PTokenInfo;
+  NxtToken: PTokenInfo;
   RemoveStartIndex: Integer;
 
   function NextToken(out Token: PTokenInfo): Boolean;
@@ -591,7 +592,20 @@ begin
           while NextToken(Token) do
           begin
             FN := '';
+
             N := Token.Value;
+
+            // Unit mit Namespace
+            while (Parser.GetToken(NxtToken, True) and (NxtToken.Kind = tkSymbol) and (NxtToken.Value = '.')) do
+            begin
+              N := N + '.';
+
+              NextToken(Token); // .
+
+              NextToken(Token); // Namespace/Name
+              N := N + Token.Value;
+            end;
+
             if SameText(N, UnitName) then
             begin
               if RemoveUnit then


### PR DESCRIPTION
Wenn Units mit Namespaces (Name.Space.Unit) im uses-Teil einer Projektdatei vorhanden sind, warf der PascalParser in AppendRemoveUnit() immer eine Exception ('Invalid project file. ";" or "," expected but "." found').
Beim Parsen der Units daher nach vorne gucken um herauszufinden ob das nächste Token ein "." ist und somit ein Namespace-Trenner.